### PR TITLE
return product title of the object in the basket

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -184,7 +184,7 @@ class BasketSummaryView(BasketView):
             )
 
         return {
-            'product_title': course_name,
+            'product_title': product.title,
             'course_key': course_key,
             'image_url': image_url,
             'product_description': short_description,


### PR DESCRIPTION
It was changed because there are problems with the course races and None was returned.