### PR TITLE
Changing responses POST from Payu

### DIFF
--- a/ecommerce/extensions/payment/views/payu.py
+++ b/ecommerce/extensions/payment/views/payu.py
@@ -132,7 +132,7 @@ class PayUPaymentResponseView(EdxOrderPlacementMixin, View):
                     return HttpResponse()
         except:  # pylint: disable=bare-except
             logger.exception('Attempts to handle payment for basket [%d] failed.', basket.id)
-            return HttpResponse(status=500)
+            return HttpResponse(status=200)
 
         try:
             # Note (CCB): In the future, if we do end up shipping physical products, we will need to
@@ -162,7 +162,7 @@ class PayUPaymentResponseView(EdxOrderPlacementMixin, View):
             return HttpResponse()
         except Exception as e:  # pylint: disable=bare-except
             logger.exception(self.order_placement_failure_msg, basket.id, str(e))
-            return HttpResponse(status=500)
+            return HttpResponse(status=200)
 
     def get(self, request, *args, **kwargs):
         # pylint: disable=unused-argument


### PR DESCRIPTION
Instead of responding with HTTP 500 status code on payu notify error, responding with 200 status to prevent the notify url to be banned.

@diegomillan 
@cocococosti 