### PR TITLE
ECOM-CAMROM-011: return product title of the object in the basket

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -206,7 +206,7 @@ class BasketSummaryView(BasketView):
             )
 
         return {
-            'product_title': course_name,
+            'product_title': product.title,
             'course_key': course_key,
             'image_url': image_url,
             'product_description': short_description,


### PR DESCRIPTION
Waiting for https://github.com/eduNEXT/ecommerce/pull/16 to rebase this.

Tested in dev, works correctly.