### PR TITLE
ECOM-CAMROM-015: change contact url in checkout error template

### DIFF
--- a/ecommerce/templates/oscar/checkout/error.html
+++ b/ecommerce/templates/oscar/checkout/error.html
@@ -16,7 +16,7 @@
             <div class="depth depth-2 message-error-content">
                 <h1>{% trans "Checkout Error" %}</h1>
                 <p>{% trans "An error has occurred with your payment." %} <b>{% trans "You have not been charged." %}</b></p>
-                <p>{% with "<a class='nav-link' href='https://support.edx.org/hc/en-us/articles/115000914088-Why-is-my-upgrade-payment-failing-'>"|safe as start_link %}
+                <p>{% with "<a class='nav-link' href='https://www.campusromero.pe/consultas#form'>"|safe as start_link %}
                     {% blocktrans with end_link="</a>"|safe %}
                     Please try to submit your payment again. If this problem persists, please refer to our {{ start_link }}
                     Payments FAQ {{ end_link }} for troubleshooting tips.


### PR DESCRIPTION
This PR sets the correct link in the checkout error page. The link should redirect to the organization's support page.

The url of the checkout error page is `http://localhost:18130/checkout/error/ ` and it should look like:

![Screenshot_2019-11-26 Error en el proceso de pago](https://user-images.githubusercontent.com/24628951/69658710-1a6e7d00-1053-11ea-83c3-744c8f244bef.png)





Tested in dev, works OK.