### PR TITLE
ECOM-CAMROM-016 : Adding google tag manager

### DIFF
--- a/ecommerce/templates/edx/base.html
+++ b/ecommerce/templates/edx/base.html
@@ -8,6 +8,13 @@
 <!DOCTYPE html>
 <html lang={{ LANGUAGE_CODE }}>
 <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5M26HM');</script>
+    <!-- End Google Tag Manager -->
     <link rel="shortcut icon" href="{% static 'images/favicon.ico' %}"/>
     <link rel="apple-touch-icon" href="{% static 'images/touch-icon.png' %}">
     <link rel="apple-touch-icon" sizes="120x120" href="{% static 'images/touch-icon-2x.png' %}">
@@ -31,6 +38,10 @@
     {% endcompress %}
 </head>
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5M26HM"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
 {% block skip_link %}
 {% endblock skip_link %}
 


### PR DESCRIPTION
This PR adds [the google tag manager](https://www.google.com/intl/es/tagmanager/) functionality to the ecommerce site.