### PR TITLE
ECOM-CAMROM-019: Changing price validation on the frontend

### DIFF
--- a/ecommerce/static/templates/professional_course_seat_form_field.html
+++ b/ecommerce/static/templates/professional_course_seat_form_field.html
@@ -10,7 +10,7 @@
 
             <div class="input-group">
                 <div class="input-group-addon">$</div>
-                <input type="number" class="form-control" name="price" id="price" min="5" step="1" pattern="\d+"
+                <input type="number" class="form-control" name="price" id="price" min="5" step="0.01" pattern="\d+"
                        value="<%= price %>">
             </div>
             <!-- NOTE: This help-block is here for validation messages. -->

--- a/ecommerce/static/templates/verified_course_seat_form_field.html
+++ b/ecommerce/static/templates/verified_course_seat_form_field.html
@@ -11,7 +11,7 @@
 
             <div class="input-group">
                 <div class="input-group-addon">$</div>
-                <input type="number" class="form-control" name="price" id="price" min="5" step="1" pattern="\d+"
+                <input type="number" class="form-control" name="price" id="price" min="5" step="0.01" pattern="\d+"
                        value="<%= price %>">
             </div>
             <!-- NOTE: This help-block is here for validation messages. -->


### PR DESCRIPTION
This PR modifies the ecommerce course seat creation site http://localhost:18130/courses/new/ to allow decimal values in the course price.

![Screenshot_2019-11-26 Crear un Curso Nuevo](https://user-images.githubusercontent.com/24628951/69660640-19d7e580-1057-11ea-84a5-ed84fe1d5bac.png)
 

Tested in dev, works ok.