### PR TITLE
Add capability to restrict course purchases in PayU using the BIN codes

### DIFF
--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -142,7 +142,8 @@ class Course(models.Model):
             expires=None,
             credit_hours=None,
             remove_stale_modes=True,
-            create_enrollment_code=False
+            create_enrollment_code=False,
+            allowed_bin=None
     ):
         """
         Creates course seat products.
@@ -236,6 +237,9 @@ class Course(models.Model):
 
         if credit_hours:
             seat.attr.credit_hours = credit_hours
+
+        if allowed_bin is not None:
+            seat.attr.allowed_bin = allowed_bin
 
         seat.attr.save()
 

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -465,6 +465,7 @@ class SeatProductHelper(object):
         certificate_type = attrs.get('certificate_type', '')
         id_verification_required = attrs['id_verification_required']
         price = Decimal(product['price'])
+        allowed_bin = attrs.get('allowed_bin', '')
 
         # Extract arguments which are optional for Seat creation, deserializing as necessary.
         expires = product.get('expires')
@@ -480,7 +481,8 @@ class SeatProductHelper(object):
             expires=expires,
             credit_provider=credit_provider,
             credit_hours=credit_hours,
-            create_enrollment_code=create_enrollment_code
+            create_enrollment_code=create_enrollment_code,
+            allowed_bin=allowed_bin
         )
 
 

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -85,6 +85,23 @@ class Basket(AbstractBasket):
             track_segment_event(self.site, self.owner, 'Product Added', properties)
         return line, created
 
+    def get_allowed_bin(self):
+        """
+        Iterate over the products of the basket and concatenate all
+        the allowed_bin attributes that are present in them.
+        """
+        allowed_bins_set = set()
+        for line in self.all_lines():
+            allowed_bin_attr = line.product.attributes.filter(name='allowed_bin').first()
+            if allowed_bin_attr:
+                allowed_bins  = set(
+                    line.product.attribute_values.get(
+                        attribute=allowed_bin_attr
+                        ).value.split(','))
+                allowed_bins_set = allowed_bins_set | allowed_bins
+
+        return ",".join(allowed_bins_set)
+
     def clear_vouchers(self):
         """Remove all vouchers applied to the basket."""
         for v in self.vouchers.all():

--- a/ecommerce/extensions/catalogue/migrations/0037_bin_list_attribute.py
+++ b/ecommerce/extensions/catalogue/migrations/0037_bin_list_attribute.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from oscar.core.loading import get_model
+
+from ecommerce.core.constants import SEAT_PRODUCT_CLASS_NAME
+
+ProductClass = get_model('catalogue', 'ProductClass')
+ProductAttribute = get_model('catalogue', 'ProductAttribute')
+
+def create_bin_list_attribute(apps, schema_editor):
+
+    seat = ProductClass.objects.get(name=SEAT_PRODUCT_CLASS_NAME)
+
+    ProductAttribute.objects.create(
+        product_class=seat,
+        name='allowed_bin',
+        code='allowed_bin',
+        type='text',
+        required=False,
+    )
+
+
+def delete_bin_list_attribute(apps, schema_editor):
+    """For backward compatibility"""
+    ProductAttribute.objects.filter(code='allowed_bin').delete()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalogue', '0036_coupon_notify_email_attribute')
+    ]
+    operations = [
+        migrations.RunPython(create_bin_list_attribute, delete_bin_list_attribute)
+    ]
+

--- a/ecommerce/extensions/payment/processors/payu.py
+++ b/ecommerce/extensions/payment/processors/payu.py
@@ -126,6 +126,10 @@ class Payu(BasePaymentProcessor):
         if self.test:
             parameters['test'] = self.test
 
+        allowed_bin = basket.get_allowed_bin()
+        if allowed_bin:
+            parameters['iin'] = allowed_bin
+
         parameters['signature'] = self._generate_signature(parameters, self.PAYMENT_FORM_SIGNATURE)
 
         return parameters
@@ -260,6 +264,8 @@ class Payu(BasePaymentProcessor):
                 amount=parameters['amount'],
                 currency=parameters['currency'],
             )
+            if parameters.get('iin', None):
+                uncoded = uncoded + "~{iin}".format(iin=parameters['iin'])
 
         # PayU applies a logic to validate signatures on confirmation page:
         # If the second decimal of the value parameter is zero, e.g. 150.00

--- a/ecommerce/static/js/models/course_seats/course_seat.js
+++ b/ecommerce/static/js/models/course_seats/course_seat.js
@@ -16,7 +16,8 @@ define([
                 price: 0,
                 credit_provider: null,
                 credit_hours: null,
-                product_class: 'Seat'
+                product_class: 'Seat',
+                allowed_bin: ''
             },
 
             course: null,
@@ -57,7 +58,12 @@ define([
                 title: {
                     required: false,
                     pattern: 'productName'
-                }
+                },
+		allowed_bin: {
+			required: true,
+			pattern: /^[0-9]{6}(,[0-9]{6})*$/,
+			msg: gettext("Allowed BIN input should be a comma separated integers list. Each BIN number should have 6 digits.")
+		}
             },
 
             // TODO Determine how to use the extended seatType attribute of child classes with Backbone.Relational

--- a/ecommerce/static/js/models/product_model.js
+++ b/ecommerce/static/js/models/product_model.js
@@ -23,7 +23,8 @@ define([
                 'course_key',
                 'id_verification_required',
                 'credit_provider',
-                'credit_hours'
+                'credit_hours',
+                'allowed_bin'
             ],
 
             parse: function(response) {

--- a/ecommerce/static/js/views/course_seat_form_fields/course_seat_form_field_view.js
+++ b/ecommerce/static/js/views/course_seat_form_fields/course_seat_form_field_view.js
@@ -38,7 +38,13 @@ define([
                 'input[name=id_verification_required]': {
                     observe: 'id_verification_required',
                     onSet: 'cleanIdVerificationRequired'
-                }
+                },
+		'input[name=allowed_bin]':{
+		  observe: 'allowed_bin',
+		  setOptions: {
+			validate: true
+		  }
+		}
             },
 
             className: function() {

--- a/ecommerce/static/templates/professional_course_seat_form_field.html
+++ b/ecommerce/static/templates/professional_course_seat_form_field.html
@@ -55,4 +55,14 @@
             </label>
         </div>
     </div>
+   <div class="allowed_bin">
+      <div class="form-group">
+         <label for="allowed_bin"><%= gettext('Allowed BIN') %></label>
+            <div class="input-group">
+                    <input type="text" class="form-control" name="allowed_bin" id="allowed_bin" placeholder="e.g: 4111111,123456" value="<% allowed_bin %>" >
+            </div>
+            <!-- NOTE: This help-block is here for validation messages. -->
+            <span class="help-block"></span>
+      </div>
+   </div>
 </div>

--- a/ecommerce/static/templates/verified_course_seat_form_field.html
+++ b/ecommerce/static/templates/verified_course_seat_form_field.html
@@ -39,4 +39,16 @@
 <div class="col-sm-4 seat-certificate-type">
     <%= gettext('Verified Certificate') %>
 </div>
-<div class="col-sm-4 seat-additional-info"></div>
+<div class="col-sm-4 seat-certificate-type">
+   <div class="allowed_bin">
+      <div class="form-group">
+         <label for="allowed_bin"><%= gettext('Allowed BINs') %></label>
+            <div class="input-group">
+		    <input type="text" class="form-control" name="allowed_bin" id="allowed_bin" placeholder="e.g: 4111111,123456" value="<% allowed_bin %>" >
+            </div>
+            <!-- NOTE: This help-block is here for validation messages. -->
+            <span class="help-block"></span>
+      </div>
+   </div>
+</div>
+</div>


### PR DESCRIPTION
Related to ticket #11752

This PR adds the capability to restrict the purchase of some courses by setting the allowed_bin attribute. 

BIN means Bank Identifier Number, and we can restrict the allowed BINs in payu by setting the iin parameter and adding that to the signature. That is not in their public documentation but it was provided by their support team.

After this change, the course edit/create view looks like this:

![image](https://user-images.githubusercontent.com/22335041/91892466-b4a5c600-ec60-11ea-882c-d7055a1f2bc6.png)

Allowed BIN  input is a comma separated integer list.

This is the error in Payu if we try to pay with a not allowed credit card.

![image](https://user-images.githubusercontent.com/22335041/91892792-41508400-ec61-11ea-96ee-a3eaa6f1b6cf.png)

The regex pattern to validate the BIN was added due to a error that happens if there is a BIN number with a length different than 6

![image](https://user-images.githubusercontent.com/22335041/91893304-ebc8a700-ec61-11ea-9550-f73df95e2500.png)





