### PR TITLE
After purchase in payu redirect to a custom static page

### DIFF
--- a/ecommerce/extensions/payment/views/payu.py
+++ b/ecommerce/extensions/payment/views/payu.py
@@ -7,6 +7,7 @@ from django.db import transaction
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.core.exceptions import ObjectDoesNotExist
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django.http import HttpResponse
@@ -190,7 +191,8 @@ class PayUPaymentResponseView(EdxOrderPlacementMixin, View):
 
         receipt_url = get_receipt_page_url(
             order_number=basket.order_number,
-            site_configuration=basket.site.siteconfiguration
+            site_configuration=basket.site.siteconfiguration,
+            override_url = settings.PAYU_RECEIPT_URL
         )
 
         try:

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -652,3 +652,6 @@ SAILTHRU_SECRET = None
 
 # Edunext setting: url path to the campus romero open edx extensions plugin
 OPENEDX_EXTENSIONS_API_URL = "/camrom/api/v1/"
+
+# Edunext setting: custom receipt page the user gets redirected to after succesfull purchase in Payu
+PAYU_RECEIPT_URL = 'https://www.campusromero.pe/compra-exitosa/'


### PR DESCRIPTION
This PR changes the receipt URL (the URL users are redirected to after successful purchase in Payu) to a static page developed by Campus.

They needed a static page to track purchases with Google Analytics. 

Tested this in Stage and worked correctly.

Ticket #12141
