### PR TITLE
JU/ECOM-CAMROM-009: Add PayU payment processor

### DIFF
--- a/ecommerce/extensions/payment/processors/payu.py
+++ b/ecommerce/extensions/payment/processors/payu.py
@@ -1,0 +1,308 @@
+""" PayU payment processing. """
+import logging
+from decimal import Decimal
+from hashlib import md5
+from urllib.parse import urljoin
+
+import requests
+from django.core.exceptions import ObjectDoesNotExist
+from django.conf import settings
+from oscar.apps.payment.exceptions import GatewayError, TransactionDeclined
+from oscar.core.loading import get_model
+from requests.exceptions import ConnectionError, Timeout, RequestException
+from slumber.exceptions import SlumberBaseException
+
+from ecommerce.core.models import User
+from ecommerce.core.url_utils import get_ecommerce_url, get_lms_url
+from ecommerce.extensions.payment.exceptions import InvalidSignatureError
+from ecommerce.extensions.payment.processors import BasePaymentProcessor, HandledProcessorResponse
+
+logger = logging.getLogger(__name__)
+
+PaymentEvent = get_model("order", "PaymentEvent")
+PaymentEventType = get_model("order", "PaymentEventType")
+ProductClass = get_model("catalogue", "ProductClass")
+Source = get_model("payment", "Source")
+SourceType = get_model("payment", "SourceType")
+
+
+class Payu(BasePaymentProcessor):
+    """
+    PayU payment processor (November 2016)
+
+    For reference, see
+    http://developers.payulatam.com/en/web_checkout/integration.html
+    """
+
+    NAME = "payu"
+    TRANSACTION_ACCEPTED = "4"
+    TRANSACTION_DECLINED = "6"
+    TRANSACTION_ERROR = "104"
+    PAYMENT_FORM_SIGNATURE = 1
+    CONFIRMATION_SIGNATURE = 2
+    DESCRIPTION_PREFIX = "Inscripción"
+    DESCRIPTION_SEPARATOR = " | "
+    MAX_SPLITS = 1
+
+    def __init__(self, site):
+        """
+        Constructs a new instance of the PayU processor.
+
+        Raises:
+            KeyError: If no settings configured for this payment processor
+            AttributeError: If LANGUAGE_CODE setting is not set.
+        """
+        super(Payu, self).__init__(site)
+        configuration = self.configuration
+        self.payment_page_url = configuration["payment_page_url"]
+        self.merchant_id = configuration["merchant_id"]
+        self.account_id = configuration["account_id"]
+        self.api_key = configuration["api_key"]
+        self.tax = configuration["tax"]
+        self.tax_return_base = configuration["tax_return_base"]
+        self.test = configuration.get("test")
+
+        self.response_url = get_ecommerce_url("/payment/payu/notify/")
+        self.confirmation_url = get_ecommerce_url("/payment/payu/notify/")
+
+    def get_transaction_parameters(self, basket, request=None, use_client_side_checkout=False, **kwargs):
+        """
+        Generate a dictionary of signed parameters PayU requires to complete a transaction.
+
+        Arguments:
+            basket (Basket): The basket of products being purchased.
+
+        Keyword Arguments:
+            request (Request): A Request object which could be used to construct an absolute URL; not
+                used by this method.
+
+        Returns:
+            dict: PayU-specific parameters required to complete a transaction, including a signature.
+        """
+        self._verify_student(request.site, request.user)
+        parameters = {
+            "payment_page_url": self.payment_page_url,
+            "merchantId": self.merchant_id,
+            "accountId": self.account_id,
+            "ApiKey": self.api_key,
+            "referenceCode": basket.order_number,
+            "tax": self.tax,
+            "taxReturnBase": self.tax_return_base,
+            "currency": basket.currency,
+            "buyerEmail": basket.owner.email,
+            "buyerFullName": basket.owner.full_name,
+            "amount": str(basket.total_incl_tax),
+            "responseUrl": self.response_url,
+            "confirmationUrl": self.confirmation_url,
+        }
+
+        description = "{} {}".format(self.DESCRIPTION_PREFIX, self.get_description(basket))
+        parameters["description"] = description
+
+        dni, name = self.get_user_details(request, basket)
+        if dni:
+            parameters["payerDocument"] = dni
+
+        if name:
+            # passing the same name for buyer and payer as requested by campus romero
+            parameters["payerFullName"] = name
+            parameters["buyerFullName"] = name
+
+        if self.test:
+            parameters["test"] = self.test
+
+        parameters["signature"] = self._generate_signature(parameters, self.PAYMENT_FORM_SIGNATURE)
+
+        return parameters
+
+    def get_description(self, basket):
+        """
+        Returns a unified description for all the products in the basket.
+        """
+        try:
+            seat_class = ProductClass.objects.get(slug="seat")
+        except ProductClass.DoesNotExist:
+            # this occurs in test configurations where the seat product class is not in use
+            return None
+
+        descriptions = []
+        for line in basket.lines.all():
+            if line.product.get_product_class() == seat_class:
+                # Assuming a course locator with the following format: course-v1:CVR+SAC01+2019
+                # we are extracting the course_id and run part of it
+                # returning SAC01+2019, for the example given above.
+                # This must be done for every course in the basket.
+                splitted_course_id = line.product.course_id.split("+", self.MAX_SPLITS)
+                descriptions.append(splitted_course_id[1].replace("+", "/"))
+
+        return self.DESCRIPTION_SEPARATOR.join(descriptions)
+
+    @staticmethod
+    def get_user_details(request, basket):
+        """
+        Returns the buyer user (edxapp user) details
+        Returns None if an exception occurs
+        """
+        def get_extended_profile_field(account_details, field_name, default_value=None):
+            """Helper function to retrieve fields from extended profile."""
+            return next(
+                (
+                    field.get("field_value", default_value)
+                    for field in account_details["extended_profile"]
+                    if field["field_name"] == field_name
+                ),
+                default_value,
+            )
+
+        try:
+            buyer_user = User.objects.get(email=basket.owner.email)
+            response = buyer_user.account_details(request)
+            dni = get_extended_profile_field(response, "dni", "")
+            return dni, response["name"]
+        except (ConnectionError, SlumberBaseException, Timeout, ObjectDoesNotExist):
+            logger.exception("Failed to retrieve user details for [%s]", basket.owner.email)
+            return None, None
+
+    def handle_processor_response(self, response, basket=None):
+        """
+        Handle a response (i.e., "merchant notification") from PayU.
+
+        This method does the following:
+            1. Verify the validity of the response.
+            2. Create PaymentEvents and Sources for successful payments.
+
+        Arguments:
+            response (dict): Dictionary of parameters received from the payment processor.
+
+        Keyword Arguments:
+            basket (Basket): Basket being purchased via the payment processor.
+
+        Raises:
+            TransactionDeclined: Indicates the payment was declined by the processor.
+            GatewayError: Indicates a general error on the part of the processor.
+            InvalidPayUDecision: Indicates an unknown decision value
+        """
+
+        # Validate the signature
+        if not self.is_signature_valid(response):
+            raise InvalidSignatureError
+
+        # Raise an exception for payments that were not accepted. Consuming code should be responsible for handling
+        # and logging the exception.
+        transaction_state = response["state_pol"]
+        if transaction_state != self.TRANSACTION_ACCEPTED:
+            exception = {
+                self.TRANSACTION_DECLINED: TransactionDeclined,
+                self.TRANSACTION_ERROR: GatewayError,
+            }.get(transaction_state, InvalidPayUDecision)
+
+            raise exception
+
+        currency = response.get("currency")
+        total = Decimal(response.get("value"))
+        transaction_id = response.get("transaction_id")
+        card_number = response.get("cc_number", "")
+        card_type = response.get("lapPaymentMethod", "")
+
+        return HandledProcessorResponse(
+            transaction_id=transaction_id,
+            total=total,
+            currency=currency,
+            card_number=card_number,
+            card_type=card_type,
+        )
+
+    def _generate_signature(self, parameters, signature_type):
+        """
+        Sign the contents of the provided transaction parameters dictionary.
+
+        This allows PayU to verify that the transaction parameters have not been tampered with
+        during transit.
+
+        We also use this signature to verify that the signature we get back from PayU is valid for
+        the parameters that they are giving to us.
+
+        Arguments:
+            parameters (dict): A dictionary of transaction parameters.
+
+        Returns:
+            unicode: the signature for the given parameters
+        """
+
+        # PayU applies a logic to validate signatures on confirmation page:
+        # If the second decimal of the value parameter is zero, e.g. 150.00
+        # the parameter new_value to generate the signature should only have one decimal, as follows: 150.0
+        # If the second decimal of the value parameter is different from zero, e.g. 150.26
+        # the parameter new_value to generate the signature should have two decimals, as follows: 150.26
+        # See http://developers.payulatam.com/en/web_checkout/integration.html
+        # signatures to validate confirmation response
+        if signature_type == self.CONFIRMATION_SIGNATURE:
+            value = parameters["value"]
+            value = value[:-1] if value.endswith("0") else value
+
+            uncoded = "{api_key}~{merchant_id}~{reference_sale}~{value}~{currency}~{state_pol}".format(
+                api_key=self.api_key,
+                merchant_id=self.merchant_id,
+                reference_sale=parameters["reference_sale"],
+                value=value,
+                currency=parameters["currency"],
+                state_pol=parameters["state_pol"],
+            )
+
+        # Signature to validate payment form
+        if signature_type == self.PAYMENT_FORM_SIGNATURE:
+            uncoded = "{api_key}~{merchant_id}~{reference_code}~{amount}~{currency}".format(
+                api_key=self.api_key,
+                merchant_id=self.merchant_id,
+                reference_code=parameters["referenceCode"],
+                amount=parameters["amount"],
+                currency=parameters["currency"],
+            )
+
+        return md5(uncoded.encode("utf-8")).hexdigest()
+
+    def is_signature_valid(self, response):
+        """Returns a boolean indicating if the response's signature (indicating potential tampering) is valid."""
+        return response and (self._generate_signature(response, self.CONFIRMATION_SIGNATURE) == response.get("sign"))
+
+    def issue_credit(self, order, reference_number, amount, currency):  # pylint: disable=unused-argument
+        """
+        This method should be implemented in the future in order
+        to accept payment refunds
+        see http://developers.payulatam.com/en/api/refunds.html
+        """
+
+        logger.exception("PayU processor can not issue credits or refunds")
+
+        raise NotImplementedError
+
+    def _verify_student(self, site, user):
+        """
+        Verify the student identity.
+
+        This method is traversal to the platform, it updates the user verification data
+        and it's not dependant of the course that is being purchased.
+
+        This is a bad practice, since it is forcefully verifying the user and it does so
+        in a unrelated point of the code.
+
+        """
+        path_api = settings.OPENEDX_EXTENSIONS_API_URL
+        url = urljoin(get_lms_url(path_api), "change_to_verified_mode/")
+        access_token = site.siteconfiguration.access_token
+
+        headers = {
+            "authorization": "JWT {}".format(access_token),
+        }
+
+        data = {"username": user.username}
+
+        try:
+            response = requests.post(url, json=data, headers=headers)
+            response.raise_for_status()
+        except RequestException as err:
+            raise err
+
+
+class InvalidPayUDecision(GatewayError):
+    """The decision returned by PayU was not recognized."""

--- a/ecommerce/extensions/payment/urls.py
+++ b/ecommerce/extensions/payment/urls.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.conf.urls import include, url
 
-from ecommerce.extensions.payment.views import PaymentFailedView, SDNFailure, cybersource, paypal, stripe
+from ecommerce.extensions.payment.views import PaymentFailedView, SDNFailure, cybersource, paypal, stripe, payu
 
 CYBERSOURCE_APPLE_PAY_URLS = [
     url(r'^authorize/$', cybersource.CybersourceApplePayAuthorizationView.as_view(), name='authorize'),
@@ -20,6 +20,10 @@ PAYPAL_URLS = [
     url(r'^profiles/$', paypal.PaypalProfileAdminView.as_view(), name='profiles'),
 ]
 
+PAYU_URLS = [
+    url(r'^notify/$', payu.PayUPaymentResponseView.as_view(), name='notify'),
+]
+
 SDN_URLS = [
     url(r'^failure/$', SDNFailure.as_view(), name='failure'),
 ]
@@ -34,4 +38,5 @@ urlpatterns = [
     url(r'^paypal/', include((PAYPAL_URLS, 'paypal'))),
     url(r'^sdn/', include((SDN_URLS, 'sdn'))),
     url(r'^stripe/', include((STRIPE_URLS, 'stripe'))),
+    url(r'^payu/', include((PAYU_URLS, 'payu'))),
 ]

--- a/ecommerce/extensions/payment/views/payu.py
+++ b/ecommerce/extensions/payment/views/payu.py
@@ -1,0 +1,198 @@
+""" PayU payment processing views """
+import logging
+
+from django.views.generic import View
+from django.db import transaction
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from django.core.exceptions import ObjectDoesNotExist
+from django.urls import reverse
+from django.shortcuts import redirect
+from django.http import HttpResponse
+
+from oscar.apps.partner import strategy
+from oscar.core.loading import get_class, get_model
+from oscar.apps.payment.exceptions import PaymentError, TransactionDeclined
+
+from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
+from ecommerce.extensions.checkout.utils import get_receipt_page_url
+from ecommerce.extensions.payment.exceptions import InvalidSignatureError
+from ecommerce.extensions.payment.processors.payu import Payu
+
+logger = logging.getLogger(__name__)
+
+Applicator = get_class("offer.applicator", "Applicator")
+Basket = get_model("basket", "Basket")
+BillingAddress = get_model("order", "BillingAddress")
+Country = get_model("address", "Country")
+NoShippingRequired = get_class("shipping.methods", "NoShippingRequired")
+OrderNumberGenerator = get_class("order.utils", "OrderNumberGenerator")
+OrderTotalCalculator = get_class("checkout.calculators", "OrderTotalCalculator")
+
+
+class PayUPaymentResponseView(EdxOrderPlacementMixin, View):
+    """Validates a response from PayU and processes the associated basket/order appropriately."""
+
+    @property
+    def payment_processor(self):
+        return Payu(self.request.site)
+
+    # Disable atomicity for the view. Otherwise, we'd be unable to commit to the database
+    # until the request had concluded; Django will refuse to commit when an atomic() block
+    # is active, since that would break atomicity. Without an order present in the database
+    # at the time fulfillment is attempted, asynchronous order fulfillment tasks will fail.
+    @method_decorator(transaction.non_atomic_requests)
+    @method_decorator(csrf_exempt)
+    def dispatch(self, request, *args, **kwargs):
+        return super(PayUPaymentResponseView, self).dispatch(request, *args, **kwargs)
+
+    def _get_billing_address(self, payu_response):
+
+        return BillingAddress(
+            first_name=payu_response.get("cc_holder", ""),
+            last_name=payu_response.get("cc_holder", ""),
+            line1=payu_response["billing_address"],
+            # Oscar uses line4 for city
+            line4=payu_response["billing_city"],
+            country=Country.objects.get(iso_3166_1_a2=payu_response["billing_country"]),
+        )
+
+    def _get_basket(self, basket_id):
+        if not basket_id:
+            return None
+
+        try:
+            basket_id = int(basket_id)
+            basket = Basket.objects.get(id=basket_id)
+            basket.strategy = strategy.Default()
+            Applicator().apply(basket, basket.owner, self.request)
+            return basket
+        except (ValueError, ObjectDoesNotExist):
+            return None
+
+    def post(self, request):
+        """Process a PayU merchant notification and place an order for paid products as appropriate."""
+
+        # Note (CCB): Orders should not be created until the payment processor has validated the response's signature.
+        # This validation is performed in the handle_payment method. After that method succeeds, the response can be
+        # safely assumed to have originated from PayU.
+        payu_response = request.POST.dict()
+        basket = None
+        transaction_id = None
+
+        try:
+            transaction_id = payu_response.get("transaction_id")
+            order_number = payu_response.get("reference_sale")
+            basket_id = OrderNumberGenerator().basket_id(order_number)
+
+            logger.info(
+                "Received PayU merchant notification for transaction [%s], associated with basket [%d].",
+                transaction_id,
+                basket_id,
+            )
+
+            basket = self._get_basket(basket_id)
+
+            if not basket:
+                logger.error("Received payment for non-existent basket [%s].", basket_id)
+                return HttpResponse(status=400)
+        finally:
+            # Store the response in the database.
+            ppr = self.payment_processor.record_processor_response(
+                payu_response, transaction_id=transaction_id, basket=basket
+            )
+
+        try:
+            # Explicitly delimit operations which will be rolled back if an exception occurs.
+            with transaction.atomic():
+                try:
+                    self.handle_payment(payu_response, basket)
+                except InvalidSignatureError:
+                    logger.exception(
+                        "Received an invalid PayU response. The payment response was recorded in entry [%d].", ppr.id
+                    )
+                    return HttpResponse(status=400)
+                except TransactionDeclined as exception:
+                    logger.info(
+                        "PayU payment did not complete for basket [%d] because [%s]. "
+                        "The payment response was recorded in entry [%d].",
+                        basket.id,
+                        exception.__class__.__name__,
+                        ppr.id,
+                    )
+                    return HttpResponse()
+                except PaymentError:
+                    logger.exception(
+                        "PayU payment failed for basket [%d]. The payment response was recorded in entry [%d].",
+                        basket.id,
+                        ppr.id,
+                    )
+                    return HttpResponse()
+        except:  # pylint: disable=bare-except
+            logger.exception("Attempts to handle payment for basket [%d] failed.", basket.id)
+            return HttpResponse(status=200)
+
+        try:
+            # Note (CCB): In the future, if we do end up shipping physical products, we will need to
+            # properly implement shipping methods. For more, see
+            # http://django-oscar.readthedocs.org/en/latest/howto/how_to_configure_shipping.html.
+            shipping_method = NoShippingRequired()
+            shipping_charge = shipping_method.calculate(basket)
+
+            # Note (CCB): This calculation assumes the payment processor has not sent a partial authorization,
+            # thus we use the amounts stored in the database rather than those received from the payment processor.
+            user = basket.owner
+            order_total = OrderTotalCalculator().calculate(basket, shipping_charge)
+            billing_address = self._get_billing_address(payu_response)
+
+            self.handle_order_placement(
+                order_number,
+                user,
+                basket,
+                None,
+                shipping_method,
+                shipping_charge,
+                billing_address,
+                order_total,
+                request=request,
+            )
+
+            return HttpResponse()
+        except Exception as e:  # pylint: disable=bare-except
+            logger.exception(self.order_placement_failure_msg, basket.id, str(e))
+            return HttpResponse(status=200)
+
+    def get(self, request, *args, **kwargs):
+        # pylint: disable=unused-argument
+        """Handle an incoming user returned to us by PayU after processing payment."""
+
+        payu_response = request.GET.dict()
+        try:
+            transaction_id = payu_response.get("transactionId")
+            order_number = payu_response.get("referenceCode")
+            basket_id = OrderNumberGenerator().basket_id(order_number)
+
+            logger.info(
+                "Received PayU payer notification for transaction [%s], associated with basket [%d].",
+                transaction_id,
+                basket_id,
+            )
+
+            basket = self._get_basket(basket_id)
+
+            if not basket:
+                logger.error("Received payer notification for non-existent basket [%s].", basket_id)
+                return redirect(reverse("payment_error"))
+        except:  # pylint: disable=bare-except
+            return redirect(reverse("payment_error"))
+
+        receipt_url = get_receipt_page_url(
+            order_number=basket.order_number,
+            site_configuration=basket.site.siteconfiguration,
+        )
+
+        try:
+            return redirect(receipt_url)
+        except Exception as e:  # pylint: disable=bare-except
+            logger.exception(self.order_placement_failure_msg, basket.id, str(e))
+            return redirect(receipt_url)

--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -120,7 +120,7 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )
 
-OSCAR_DEFAULT_CURRENCY = 'USD'
+OSCAR_DEFAULT_CURRENCY = 'PEN'
 # END ORDER PROCESSING
 
 
@@ -129,6 +129,7 @@ PAYMENT_PROCESSORS = (
     'ecommerce.extensions.payment.processors.cybersource.Cybersource',
     'ecommerce.extensions.payment.processors.paypal.Paypal',
     'ecommerce.extensions.payment.processors.stripe.Stripe',
+    'ecommerce.extensions.payment.processors.payu.Payu',
 )
 
 PAYMENT_PROCESSOR_RECEIPT_PATH = '/checkout/receipt/'

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -806,3 +806,6 @@ HUBSPOT_SALES_LEAD_FORM_GUID = "SET-ME-PLEASE"
 # To check government purchase restriction lists
 SDN_CHECK_API_URL ="https://api.trade.gov/gateway/v1/consolidated_screening_list/search"
 SDN_CHECK_API_KEY = "sdn search key here"
+
+# Edunext setting: url path to the campus romero open edx extensions plugin
+OPENEDX_EXTENSIONS_API_URL = "/camrom/api/v1/"

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -57,6 +57,20 @@ ENTERPRISE_CUSTOMERS_EXCLUDED_FROM_CATALOG = ()
 # PAYMENT PROCESSING
 PAYMENT_PROCESSOR_CONFIG = {
     'edx': {
+        'payu': {
+            'account_id': '512323',
+            'api_key': '4Vj8eK4rloUd272L48hsrarnUA',
+            'cancel_url': 'http://edx.devstack.lms/commerce/checkout/cancel/',
+            'error_url': 'http://edx.devstack.lms/commerce/checkout/error/',
+            'merchant_id': '508029',
+            'payment_page_url': 'https://sandbox.checkout.payulatam.com/ppp-web-gateway-payu/',
+            'receipt_url': 'http://edx.devstack.lms/commerce/checkout/receipt/',
+            'test': 1,
+            'tax': '0',
+            'tax_return_base': '0',
+            'receipt_path': PAYMENT_PROCESSOR_RECEIPT_PATH,
+            'cancel_checkout_path': PAYMENT_PROCESSOR_CANCEL_PATH,
+        },
         'cybersource': {
             'merchant_id': 'edx_org',
             'transaction_key': '2iJRV1OoAiMxSsFRQfkmdeqYKzwV76R5AY7vs/zKCQf2Dy0gYsno6sEizavo9rz29kcq/s2F+nGP0DrNNwDXyAxI3FW77HY+0jAssnXwd8cW1Pt5aEBcQvnOQ4i9nbN2mr1XJ+MthRbNodz1FgLFuTiZenpjFq1DFmQwFi2u7V1ItQrmG19kvnpk1++mZ8Dx7s4GdN8jxdvesNGoKo7E05X6LZTHdUCP3rfq/1Nn4RDoPvxtv9UMe77yxtUF8LVJ8clAl4VyW+6uhmgfIWninfQiESR0HQ++cNJS1EXHjwNyuDEdEALKxAwgUu4DQpFbTD1bcRRm4VrnDr6MsA8NaA==',

--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -118,3 +118,6 @@ ENTERPRISE_CUSTOMERS_EXCLUDED_FROM_CATALOG = config_from_yaml.get('ENTERPRISE_CU
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
     'use-jwt-cookie',
 )
+
+# Edunext setting: url path to the campus romero open edx extensions plugin
+OPENEDX_EXTENSIONS_API_URL = environ.get('OPENEDX_EXTENSIONS_API_URL', OPENEDX_EXTENSIONS_API_URL)

--- a/ecommerce/templates/oscar/basket/partials/hosted_checkout_basket.html
+++ b/ecommerce/templates/oscar/basket/partials/hosted_checkout_basket.html
@@ -165,6 +165,8 @@
                             {% elif processor.NAME == 'paypal' %}
                                 {# Translators: Do NOT translate the name PayPal. #}
                                 {% trans "Checkout with PayPal" as tmsg %}{{ tmsg | force_escape }}
+                            {% elif processor.NAME == 'payu' %}
+                                {% trans "Pay Here" as tmsg %}{{ tmsg | force_escape }}
                             {% endif %}
                         </button>
                     {% endfor %}


### PR DESCRIPTION
## Description

This PR adds PayU as a payment processor.

It also verifies the student identity at the moment of purchase using an API provided by the [Campus Romero plugin](https://github.com/eduNEXT/campusromero-openedx-extensions).
## How To Test

- Create a paid course.
- Create and enable a waffle switch with the name `payment_processor_active_payu`
- Create a reverse tunnel to your localhost at port 18130 via ngrok or other tool of your liking.
- Change the value of [`self.confirmation_url`](https://github.com/eduNEXT/ecommerce/blob/eb822cbaf6e2c4e01cf8fd5d388e3933a177a782/ecommerce/extensions/payment/processors/payu.py#L63) to point to the url of your reverse tunnel.
- Buy the course and proceed with the transaction following the [PayU Sandbox instructions](http://developers.payulatam.com/es/web_checkout/sandbox.html)

**Original commit:**
[`6b87f2ad`](https://github.com/eduNEXT/ecommerce/pull/18/commits/6b87f2ad9f45caaf6d79ae8082402e3c701150ff)
