### PR TITLE
JU/ECOM-CAMROM-011: Show product title in basket instead of none

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -253,7 +253,7 @@ class BasketLogicMixin:
             Also returns course information found from catalog.
         """
         course_data = {
-            'product_title': None,
+            'product_title': product.title,
             'course_key': None,
             'image_url': None,
             'product_description': None,


### PR DESCRIPTION
## Description

The basket page tries to display the title of the course based on info pulled from Discovery. In case the info can't be pulled correctly (e.g. haven't run `refresh_course_metadata` or the Discovery service is down), it shows None as a product title.

Now it defaults to the course title that was used when creating the product in ecommerce.

## How to test

- Create a new course in studio.
- Create a paid track in ecommerce.
-  The basket should no longer say 'None'.

**Original commit:**
[`c6194db`](https://github.com/eduNEXT/ecommerce/pull/17/commits/c6194dbf606baf9fbf6f724fd0d4485b5bf1e13c)