### PR TITLE
JU/ECOM-CAMROM-013: Add waffle switch to disable the link to switch the sku on the checkout page

### DIFF
--- a/ecommerce/extensions/basket/constants.py
+++ b/ecommerce/extensions/basket/constants.py
@@ -1,3 +1,4 @@
 TEMPORARY_BASKET_CACHE_KEY = "ecommerce.is_calculate_temporary_basket"
 EMAIL_OPT_IN_ATTRIBUTE = "email_opt_in"
 PURCHASER_BEHALF_ATTRIBUTE = "purchased_for_organization"
+DISABLE_CHECKOUT_SKU_SWITCH_NAME = "disable_checkout_sku_switch"

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -46,7 +46,7 @@ from ecommerce.extensions.analytics.utils import (
     translate_basket_line_for_segment
 )
 from ecommerce.extensions.basket import message_utils
-from ecommerce.extensions.basket.constants import EMAIL_OPT_IN_ATTRIBUTE
+from ecommerce.extensions.basket.constants import EMAIL_OPT_IN_ATTRIBUTE, DISABLE_CHECKOUT_SKU_SWITCH_NAME
 from ecommerce.extensions.basket.exceptions import BadRequestException, RedirectException, VoucherException
 from ecommerce.extensions.basket.utils import (
     add_invalid_code_message_to_url,
@@ -140,7 +140,8 @@ class BasketLogicMixin:
                 }
 
             context_updates['order_details_msg'] = self._get_order_details_message(product)
-            context_updates['switch_link_text'], context_updates['partner_sku'] = get_basket_switch_data(product)
+            if not waffle.switch_is_active(DISABLE_CHECKOUT_SKU_SWITCH_NAME):
+                context_updates['switch_link_text'], context_updates['partner_sku'] = get_basket_switch_data(product)
 
             line_data.update({
                 'sku': product.stockrecords.first().partner_sku,


### PR DESCRIPTION
## Description
Adds a waffle switch `disable_checkout_sku_switch` to disable the link in the basket that switches between single and bulk purchase.

## How to test
- Add and enable the switch through django admin
- Go to the basket page and the link should no longer appear

**Before:**
![image](https://user-images.githubusercontent.com/69784365/133131766-abe08436-c5d6-49c2-a792-378f193d2afe.png)
**After:**
![image](https://user-images.githubusercontent.com/69784365/133132590-b27da250-d25b-4c24-a42d-f974ed70f05b.png)


**Original Commit:**
[`de87241`](https://github.com/eduNEXT/ecommerce/pull/20/commits/de872411ba8cf15637f55516a736cad7d24687d7)