### PR TITLE
JU/ECOM-CAMROM-023: Redirect to custom page after PayU Purchase

### DIFF
--- a/ecommerce/extensions/payment/views/payu.py
+++ b/ecommerce/extensions/payment/views/payu.py
@@ -6,6 +6,7 @@ from django.db import transaction
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.core.exceptions import ObjectDoesNotExist
+from django.conf import settings
 from django.urls import reverse
 from django.shortcuts import redirect
 from django.http import HttpResponse
@@ -189,6 +190,7 @@ class PayUPaymentResponseView(EdxOrderPlacementMixin, View):
         receipt_url = get_receipt_page_url(
             order_number=basket.order_number,
             site_configuration=basket.site.siteconfiguration,
+            override_url=settings.PAYU_RECEIPT_URL,
         )
 
         try:

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -809,3 +809,6 @@ SDN_CHECK_API_KEY = "sdn search key here"
 
 # Edunext setting: url path to the campus romero open edx extensions plugin
 OPENEDX_EXTENSIONS_API_URL = "/camrom/api/v1/"
+
+# Edunext setting: custom receipt page the user gets redirected to after succesfull purchase in Payu
+PAYU_RECEIPT_URL = 'https://www.campusromero.pe/compra-exitosa/'


### PR DESCRIPTION
## Description
Redirects users to a custom page developed by Campus Romero instead of the original `receipt_url` to allow purchase tracking with Google Analytics.

## How to test
- Complete a purchase. You should be redirected to https://www.campusromero.pe/compra-exitosa/
 
**Original Commit:**
[`9244dea`](https://github.com/eduNEXT/ecommerce/pull/29/commits/9244dead8acf846b0d77d3ad5f40d1354b656dab)