### PR TITLE
JU/ECOM-CAMROM-022: Allow course purchase restrictions in PayU using the BIN codes

### DIFF
--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -151,6 +151,7 @@ class Course(models.Model):
             remove_stale_modes=True,
             create_enrollment_code=False,
             sku=None,
+            allowed_bin=None,
     ):
         """
         Creates and updates course seat products.
@@ -224,6 +225,9 @@ class Course(models.Model):
 
         if credit_hours:
             seat.attr.credit_hours = credit_hours
+
+        if allowed_bin is not None:
+            seat.attr.allowed_bin = allowed_bin
 
         seat.attr.save()
 

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -513,6 +513,7 @@ class SeatProductHelper:
         certificate_type = attrs.get('certificate_type', '')
         id_verification_required = attrs['id_verification_required']
         price = Decimal(product['price'])
+        allowed_bin = attrs.get('allowed_bin', '')
 
         # Extract arguments which are optional for Seat creation, deserializing as necessary.
         expires = product.get('expires')
@@ -534,6 +535,7 @@ class SeatProductHelper:
             credit_hours=credit_hours,
             create_enrollment_code=create_enrollment_code,
             sku=sku,
+            allowed_bin=allowed_bin,
         )
 
         # As a convenience to our caller, provide the SKU in the returned product serialization.

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -89,6 +89,23 @@ class Basket(AbstractBasket):
             track_segment_event(self.site, self.owner, 'Product Added', properties)
         return line, created
 
+    def get_allowed_bin(self):
+        """
+        Iterate over the products of the basket and concatenate all
+        the allowed_bin attributes that are present in them.
+        """
+        allowed_bins_set = set()
+        for line in self.all_lines():
+            allowed_bin_attr = line.product.attributes.filter(name='allowed_bin').first()
+            if allowed_bin_attr:
+                allowed_bins  = set(
+                    line.product.attribute_values.get(
+                        attribute=allowed_bin_attr
+                        ).value.split(','))
+                allowed_bins_set = allowed_bins_set | allowed_bins
+
+        return ",".join(allowed_bins_set)
+
     def clear_vouchers(self):
         """Remove all vouchers applied to the basket."""
         for v in self.vouchers.all():

--- a/ecommerce/extensions/payment/processors/payu.py
+++ b/ecommerce/extensions/payment/processors/payu.py
@@ -116,6 +116,10 @@ class Payu(BasePaymentProcessor):
         if self.test:
             parameters["test"] = self.test
 
+        allowed_bin = basket.get_allowed_bin()
+        if allowed_bin:
+            parameters["iin"] = allowed_bin
+
         parameters["signature"] = self._generate_signature(parameters, self.PAYMENT_FORM_SIGNATURE)
 
         return parameters
@@ -279,6 +283,7 @@ class Payu(BasePaymentProcessor):
                 amount=parameters["amount"],
                 currency=parameters["currency"],
             )
+            uncoded += "~{iin}".format(iin=parameters["iin"]) if parameters.get("iin") else ''
 
         return md5(uncoded.encode("utf-8")).hexdigest()
 

--- a/ecommerce/static/js/models/course_seats/course_seat.js
+++ b/ecommerce/static/js/models/course_seats/course_seat.js
@@ -16,7 +16,8 @@ define([
                 price: 0,
                 credit_provider: null,
                 credit_hours: null,
-                product_class: 'Seat'
+                product_class: 'Seat',
+                allowed_bin: ''
             },
 
             course: null,
@@ -57,6 +58,11 @@ define([
                 title: {
                     required: false,
                     pattern: 'productName'
+                },
+                allowed_bin: {
+                    required: false,
+                    pattern: /^[0-9]{6}(,[0-9]{6})*$/,
+                    msg: gettext("Allowed BIN input should be a comma separated integers list. Each BIN number should have 6 digits.")
                 }
             },
 

--- a/ecommerce/static/js/models/product_model.js
+++ b/ecommerce/static/js/models/product_model.js
@@ -23,7 +23,8 @@ define([
                 'course_key',
                 'id_verification_required',
                 'credit_provider',
-                'credit_hours'
+                'credit_hours',
+                'allowed_bin'
             ],
 
             parse: function(response) {

--- a/ecommerce/static/js/views/course_seat_form_fields/course_seat_form_field_view.js
+++ b/ecommerce/static/js/views/course_seat_form_fields/course_seat_form_field_view.js
@@ -38,6 +38,12 @@ define([
                 'input[name=id_verification_required]': {
                     observe: 'id_verification_required',
                     onSet: 'cleanIdVerificationRequired'
+                },
+                'input[name=allowed_bin]':{
+                    observe: 'allowed_bin',
+                    setOptions: {
+                        validate: true
+                    }
                 }
             },
 

--- a/ecommerce/static/templates/professional_course_seat_form_field.html
+++ b/ecommerce/static/templates/professional_course_seat_form_field.html
@@ -55,4 +55,14 @@
             </label>
         </div>
     </div>
+   <div class="allowed_bin">
+      <div class="form-group">
+         <label for="allowed_bin"><%= gettext('Allowed BIN') %></label>
+            <div class="input-group">
+                    <input type="text" class="form-control" name="allowed_bin" id="allowed_bin" placeholder="e.g: 4111111,123456" value="<% allowed_bin %>" >
+            </div>
+            <!-- NOTE: This help-block is here for validation messages. -->
+            <span class="help-block"></span>
+      </div>
+   </div>
 </div>

--- a/ecommerce/static/templates/verified_course_seat_form_field.html
+++ b/ecommerce/static/templates/verified_course_seat_form_field.html
@@ -39,4 +39,16 @@
 <div class="col-sm-4 seat-certificate-type">
     <%= gettext('Verified Certificate') %>
 </div>
-<div class="col-sm-4 seat-additional-info"></div>
+<div class="col-sm-4 seat-certificate-type">
+   <div class="allowed_bin">
+      <div class="form-group">
+         <label for="allowed_bin"><%= gettext('Allowed BINs') %></label>
+            <div class="input-group">
+		    <input type="text" class="form-control" name="allowed_bin" id="allowed_bin" placeholder="e.g: 4111111,123456" value="<% allowed_bin %>" >
+            </div>
+            <!-- NOTE: This help-block is here for validation messages. -->
+            <span class="help-block"></span>
+      </div>
+   </div>
+</div>
+</div>


### PR DESCRIPTION
## Description
Restrict the purchase of some courses depending on a list of allowed BINs (Bank Identifier Number).

A more in depth explanation can be found in: #27 

## How to test
- Create a paid course with a BIN (e.g. 411111).
- Go through the normal payment flow and use a card that is not in the BIN list.
- You should receive an error message on the PayU page.

**Original Commits:**
[`58afa6b`](https://github.com/eduNEXT/ecommerce/pull/27/commits/58afa6b3ac84b254905293dd9470cc7843489039)
[`2a05fdb`](https://github.com/eduNEXT/ecommerce/pull/28/commits/2a05fdbc5449daaab7444343db22ad23870950d9)