### PR TITLE
JU/ECOM-CAMROM-021: Force basket cleaning before calling PayU

### DIFF
--- a/ecommerce/extensions/payment/views/payu.py
+++ b/ecommerce/extensions/payment/views/payu.py
@@ -159,7 +159,7 @@ class PayUPaymentResponseView(EdxOrderPlacementMixin, View):
 
             return HttpResponse()
         except Exception as e:  # pylint: disable=bare-except
-            logger.exception(self.order_placement_failure_msg, basket.id, str(e))
+            logger.exception(self.order_placement_failure_msg, str(e), basket.id)
             return HttpResponse(status=200)
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
## Description
Removes any expired vouchers that causes the checkout to fail.

## How to test
- Create a paid course.
- Create a coupon for said course.
- Try to buy the course, once in the basket apply the coupon.
- While keeping the page open, on another tab change the coupon expiration date to any day before today.
- Reload the basket page and proceed with the payment from there.
- The payment should complete, but the purchase fails and the user is not enrolled.

## Extra info
This is related to this issue in django oscar: https://github.com/django-oscar/django-oscar/issues/3040

**Commits:**
[`026ce24`](https://github.com/eduNEXT/ecommerce/pull/26/commits/026ce2442e9fc862bdca44cc888e3b783aa1b7a9)
[`705d81e`](https://github.com/eduNEXT/ecommerce/pull/26/commits/705d81e8f6359175821a56f0c6c6d440fd8eca00)
[`929953b`](https://github.com/eduNEXT/ecommerce/pull/26/commits/929953b15f8c618a8da85964195c9ca184d51ffe)
[`7461f22`](https://github.com/eduNEXT/ecommerce/pull/26/commits/7461f22b8bf85564fef462ae94bf9ff9939b43e3)
[`7461f22`](https://github.com/eduNEXT/ecommerce/pull/26/commits/7461f22b8bf85564fef462ae94bf9ff9939b43e3)

